### PR TITLE
Combine lone blend trees

### DIFF
--- a/Editor/AnimatorOptimizer.cs
+++ b/Editor/AnimatorOptimizer.cs
@@ -270,19 +270,31 @@ namespace d4rkpl4y3r.AvatarOptimizer
                 }
                 else
                 {
-                    param = layer.states[0].state.timeParameter;
-                    float maxKeyframeTime = 0;
-                    var clip = layer.states[0].state.motion as AnimationClip;
-                    foreach (var binding in AnimationUtility.GetCurveBindings(clip))
+                    if (layer.states[0].state.motion is BlendTree blendTreeToClone)
                     {
-                        var curve = AnimationUtility.GetEditorCurve(clip, binding);
-                        maxKeyframeTime = Mathf.Max(maxKeyframeTime, curve.keys.Max(x => x.time));
+                        param = "d4rkAvatarOptimizer_MergedLayers_Weight";
+                        var clonedBlendTree = CloneBlendTree(null, blendTreeToClone);
+                        clonedBlendTree.name = $"{clonedBlendTree.name} (cloned)";
+                        clonedBlendTree.hideFlags = HideFlags.HideInHierarchy;
+                        AssetDatabase.AddObjectToAsset(clonedBlendTree, assetPath);
+                        treeMotions.Add(clonedBlendTree);
                     }
-                    treeMotions.Add(CloneFromTime(clip, 0, $"{clip.name} (0%)"));
-                    treeMotions.Add(CloneFromTime(clip, 0.25f * maxKeyframeTime, $"{clip.name} (25%)"));
-                    treeMotions.Add(CloneFromTime(clip, 0.5f * maxKeyframeTime, $"{clip.name} (50%)"));
-                    treeMotions.Add(CloneFromTime(clip, 0.75f * maxKeyframeTime, $"{clip.name} (75%)"));
-                    treeMotions.Add(CloneFromTime(clip, maxKeyframeTime, $"{clip.name} (100%)"));
+                    else
+                    {
+                        param = layer.states[0].state.timeParameter;
+                        float maxKeyframeTime = 0;
+                        var clip = layer.states[0].state.motion as AnimationClip;
+                        foreach (var binding in AnimationUtility.GetCurveBindings(clip))
+                        {
+                            var curve = AnimationUtility.GetEditorCurve(clip, binding);
+                            maxKeyframeTime = Mathf.Max(maxKeyframeTime, curve.keys.Max(x => x.time));
+                        }
+                        treeMotions.Add(CloneFromTime(clip, 0, $"{clip.name} (0%)"));
+                        treeMotions.Add(CloneFromTime(clip, 0.25f * maxKeyframeTime, $"{clip.name} (25%)"));
+                        treeMotions.Add(CloneFromTime(clip, 0.5f * maxKeyframeTime, $"{clip.name} (50%)"));
+                        treeMotions.Add(CloneFromTime(clip, 0.75f * maxKeyframeTime, $"{clip.name} (75%)"));
+                        treeMotions.Add(CloneFromTime(clip, maxKeyframeTime, $"{clip.name} (100%)"));
+                    }
                 }
                 var layerTree = new BlendTree()
                 {

--- a/Editor/d4rkAvatarOptimizerEditor.cs
+++ b/Editor/d4rkAvatarOptimizerEditor.cs
@@ -189,7 +189,7 @@ public class d4rkAvatarOptimizerEditor : Editor
         PerfRankChangeLabel("Material Slots", totalMaterialCount, optimizedTotalMaterialCount, PerformanceCategory.MaterialCount);
         if (optimizer.GetFXLayer() != null)
         {
-            var nonErrors = new HashSet<string>() {"toggle", "motion time"};
+            var nonErrors = new HashSet<string>() {"toggle", "motion time", "lone blend tree"};
             var mergedLayerCount = optimizer.OptimizeFXLayer ? optimizer.AnalyzeFXLayerMergeAbility().Count(list => list.All(e => nonErrors.Contains(e))) : 0;
             var layerCount = optimizer.GetFXLayer().layers.Length;
             var optimizedLayerCount = mergedLayerCount > 1 ? layerCount - mergedLayerCount + 1 : layerCount;
@@ -231,11 +231,11 @@ public class d4rkAvatarOptimizerEditor : Editor
                 var errorMessages = optimizer.AnalyzeFXLayerMergeAbility();
                 var uselessLayers = optimizer.FindUselessFXLayers();
                 var fxLayer = optimizer.GetFXLayer();
-                var nonErrors = new HashSet<string>() {"toggle", "motion time", "useless"};
+                var nonErrors = new HashSet<string>() {"toggle", "motion time", "useless", "lone blend tree"};
                 for (int i = 0; i < errorMessages.Count; i++)
                 {
                     var perfRating = PerformanceRating.VeryPoor;
-                    if (errorMessages[i].Count == 1 && errorMessages[i][0] == "toggle")
+                    if (errorMessages[i].Count == 1 && (errorMessages[i][0] == "toggle" || errorMessages[i][0] == "lone blend tree"))
                         perfRating = PerformanceRating.Good;
                     else if (errorMessages[i].Count == 1 && errorMessages[i][0] == "motion time")
                         perfRating = PerformanceRating.Medium;


### PR DESCRIPTION
I'm opening this Draft pull request to record whether there are any downsides in doing this.

I'm using AnimatorAsCode to generate blend trees for various items and uses across my avatar.

Using Modular Avatar, I need to choose between one of two approaches:

- A) Combine all of those blend trees myself into a Direct blend tree to be merged later. The problem with this approach is that blend trees are generated across various items before Modular Avatar has had the chance to remap relative paths of each item within the animations of the blend tree, so this choice creates a fairly complex processing problem.

- B) Create many animator controller layers that only contain a single state with a lone blend tree in each, and use a processor to combine all lone blend trees into a single one after Modular Avatar has merged all animator controllers into a single controller. This takes advantage of Modular Avatar, which will remap relative paths the animations contained within blend trees of each item appropriately.

d4rkAvatarOptimizer already has a process to transform select layers into a direct blend tree, so it could be used as the processor described in B). I'd like to ask:

- Do you see any drawbacks in combining layers that only have a single state with a single blend tree in them?
- Do you know if there are exceptions/exclusions to be made when combining blend trees?
- In this draft pull request, lone Direct blend trees found in existing layers are nested into d4rkAvatarOptimizer's direct blend tree. Are there known issues in nesting Direct blend trees into each other?