### PR TITLE
put geom wrapper struct inside same #ifs as geom function

### DIFF
--- a/Editor/ShaderAnalyzer.cs
+++ b/Editor/ShaderAnalyzer.cs
@@ -1854,7 +1854,7 @@ namespace d4rkpl4y3r.AvatarOptimizer
                 wrapperStructs.Add(outParamType + " d4rkAvatarOptimizer_geometryOutput;");
                 wrapperStructs.Add("};");
             }
-            int insertIndex = output.FindLastIndex(s => !s.StartsWith("#") && !s.StartsWith("[")) + 1;
+            int insertIndex = output.FindLastIndex(s => !(s.StartsWith("#") && !s.StartsWith("#if")) && !s.StartsWith("[")) + 1;
             output.InsertRange(insertIndex, wrapperStructs);
             string line = source[sourceLineIndex];
             while (line != "{" && sourceLineIndex < source.Count - 1)

--- a/Editor/ShaderAnalyzer.cs
+++ b/Editor/ShaderAnalyzer.cs
@@ -1838,9 +1838,11 @@ namespace d4rkpl4y3r.AvatarOptimizer
             var wrapperStructs = new List<string>();
             bool usesOutputWrapper = animatedPropertyValues.Count > 0 || arrayPropertyValues.Count > 0;
             bool usesInputWrapper = usesOutputWrapper || mergedMeshCount > 1;
+            var inputWrapperName = $"geometryInputWrapper_l{dummyLineIndex}";
+            var outputWrapperName = $"geometryOutputWrapper_l{dummyLineIndex}";
             if (usesInputWrapper)
             {
-                wrapperStructs.Add("struct geometryInputWrapper");
+                wrapperStructs.Add("struct " + inputWrapperName);
                 wrapperStructs.Add("{");
                 wrapperStructs.Add("uint d4rkAvatarOptimizer_MeshMaterialID : d4rkAvatarOptimizer_MeshMaterialID;");
                 wrapperStructs.Add(inParam.type + " d4rkAvatarOptimizer_geometryInput;");
@@ -1848,13 +1850,13 @@ namespace d4rkpl4y3r.AvatarOptimizer
             }
             if (usesOutputWrapper)
             {
-                wrapperStructs.Add("struct geometryOutputWrapper");
+                wrapperStructs.Add("struct " + outputWrapperName);
                 wrapperStructs.Add("{");
                 wrapperStructs.Add("uint d4rkAvatarOptimizer_MeshMaterialID : d4rkAvatarOptimizer_MeshMaterialID;");
                 wrapperStructs.Add(outParamType + " d4rkAvatarOptimizer_geometryOutput;");
                 wrapperStructs.Add("};");
             }
-            int insertIndex = output.FindLastIndex(s => !(s.StartsWith("#") && !s.StartsWith("#if")) && !s.StartsWith("[")) + 1;
+            int insertIndex = output.FindLastIndex(s => !s.StartsWith("#") && !s.StartsWith("[")) + 1;
             output.InsertRange(insertIndex, wrapperStructs);
             string line = source[sourceLineIndex];
             while (line != "{" && sourceLineIndex < source.Count - 1)
@@ -1864,10 +1866,10 @@ namespace d4rkpl4y3r.AvatarOptimizer
             curlyBraceDepth++;
             string geometryType = inParam.arraySize == 1 ? "point" : inParam.arraySize == 2 ? "line" : "triangle";
             output.Add($"void {func.name}({geometryType} "
-                + (usesInputWrapper ? "geometryInputWrapper d4rkAvatarOptimizer_inputWrapper" : inParam.type + " " + inParam.name)
+                + (usesInputWrapper ? inputWrapperName + " d4rkAvatarOptimizer_inputWrapper" : inParam.type + " " + inParam.name)
                 + $"[{inParam.arraySize}], inout "
                 + outParam.type.Substring(0, 7 + outParam.type.IndexOf('S'))
-                + (usesOutputWrapper ? "geometryOutputWrapper" : outParamType)
+                + (usesOutputWrapper ? outputWrapperName : outParamType)
                 + "> " + outParam.name
                 + string.Join("", func.parameters.Where(p => p.isInput && p != inParam && p != outParam).Select(p => ", " + p))
                 + ")");
@@ -1910,7 +1912,7 @@ namespace d4rkpl4y3r.AvatarOptimizer
                 else if (line.Contains(outParam.name + ".Append("))
                 {
                     output.Add("{");
-                    output.Add("geometryOutputWrapper d4rkAvatarOptimizer_geomOutput;");
+                    output.Add(outputWrapperName + " d4rkAvatarOptimizer_geomOutput;");
                     output.Add("d4rkAvatarOptimizer_geomOutput.d4rkAvatarOptimizer_geometryOutput = " + line.Substring(line.IndexOf(".Append(") + 7));
                     output.Add("d4rkAvatarOptimizer_geomOutput.d4rkAvatarOptimizer_MeshMaterialID = "
                         + "d4rkAvatarOptimizer_MaterialID | (d4rkAvatarOptimizer_MeshID << 16);");


### PR DESCRIPTION
Fixes a miscompilation for code like this:

```hlsl
#if defined(FOO)
[maxvertexcount(3)]
void geom(...)
{
    ...
}
#endif

#if defined(BAR)
[maxvertexcount(3)]
void geom(...)
{
    ...
}
#endif
```

Previously the wrapper structs would end up outside the `#if defined(FOO)` defines unnecessarily (they aren't needed when the corresponding function is not compiled anyway). This leads to a duplicate struct definition regardless of defines:

```hlsl
struct geometryInputWrapper
{
    ...
}
#if defined(FOO)
[maxvertexcount(3)]
void geom(...)
{
    ...
}
#endif

struct geometryInputWrapper        // <- duplicate definition!
{
    ...
}
#if defined(BAR)
[maxvertexcount(3)]
void geom(...)
{
    ...
}
#endif
```

The original code is perfectly valid though, as long as `FOO` and `BAR` are exclusive keywords.

This fix moves the struct definition below the `#if` which makes them exclusive to each other similar to the function itself.

### Alternative Fixes

The reason for searching until the top-most `s.StartsWith("[")` is obvious, but I wasn't sure if there was a case where the search for `s.StartsWith("#")`  was needed too, so I restricted it to only exclude conditionals.

An alternative solution would be to rename the structs, e.g. encode `dummyLineIndex` (function name wouldn't work as can be the same) into it.