### PR TITLE
fix range properties not getting their values copied to optimized shaders

### DIFF
--- a/Editor/ShaderAnalyzer.cs
+++ b/Editor/ShaderAnalyzer.cs
@@ -1404,7 +1404,7 @@ namespace d4rkpl4y3r.AvatarOptimizer
                         tex3DCubeProperties.Add(name);
                         break;
                     default:
-                        if (type.StartsWithSimple("range"))
+                        if (type.ToLowerInvariant().StartsWithSimple("range"))
                         {
                             floatProperties.Add(name);
                         }


### PR DESCRIPTION
It wasn't testing against the lowercase version of the string.