### PR TITLE
fix pass detection not working with all valid pass keywords

### DIFF
--- a/Editor/ShaderAnalyzer.cs
+++ b/Editor/ShaderAnalyzer.cs
@@ -1404,7 +1404,7 @@ namespace d4rkpl4y3r.AvatarOptimizer
                         tex3DCubeProperties.Add(name);
                         break;
                     default:
-                        if (type.StartsWithSimple("range"))
+                        if (type.ToLowerInvariant().StartsWithSimple("range"))
                         {
                             floatProperties.Add(name);
                         }

--- a/Editor/ShaderAnalyzer.cs
+++ b/Editor/ShaderAnalyzer.cs
@@ -1301,7 +1301,7 @@ namespace d4rkpl4y3r.AvatarOptimizer
                     output.Add(line == "CGPROGRAM" ? "ENDCG" : "ENDHLSL");
                     currentPass.codeBlockLineCount = output.Count - currentPass.startLineIndex - currentPass.codeBlockStartIndex;
                 }
-                else if (line == "Pass")
+                else if (line.ToLower() == "pass")
                 {
                     if (lines[lineIndex + 1] != "{")
                     {


### PR DESCRIPTION
the Pass keyword is not case sensitive but the analyzer was treating it like it was
so "pass" "pAsS" etc are all valid and will still compile the shader but were preventing it from being optimized