### PR TITLE
Ignore bindings for material properties that do not exist

### DIFF
--- a/Editor/d4rkAvatarOptimizer.cs
+++ b/Editor/d4rkAvatarOptimizer.cs
@@ -928,7 +928,7 @@ public class d4rkAvatarOptimizer : MonoBehaviour
                     int materialSlotCount = renderer.sharedMaterials.Length;
 
                     var swaps = FindAllMaterialSwapMaterials();
-                    string materialProperty = binding.propertyName.Substring("material.".Length);
+                    string materialProperty = binding.propertyName.Substring("material.".Length).Split('.', 2)[0];
 
                     bool propertyExists = false;
 

--- a/Editor/d4rkAvatarOptimizer.cs
+++ b/Editor/d4rkAvatarOptimizer.cs
@@ -934,7 +934,7 @@ public class d4rkAvatarOptimizer : MonoBehaviour
 
                     for(int i = 0; i < materialSlotCount && !propertyExists; ++i) {
                         // check the default materials
-                        if(renderer.sharedMaterials[i]?.HasProperty(materialProperty) ?? false) {
+                        if(renderer.sharedMaterials[i] != null && renderer.sharedMaterials[i].HasProperty(materialProperty)) {
                             propertyExists = true;
                             break;
                         }
@@ -942,7 +942,7 @@ public class d4rkAvatarOptimizer : MonoBehaviour
                         // check the material swaps
                         if(swaps.TryGetValue((binding.path, i), out var mats)) {
                             foreach(Material mat in mats) {
-                                if(mat?.HasProperty(materialProperty) ?? false) {
+                                if(mat != null && mat.HasProperty(materialProperty)) {
                                     propertyExists = true;
                                     break;
                                 }

--- a/Editor/d4rkAvatarOptimizer.cs
+++ b/Editor/d4rkAvatarOptimizer.cs
@@ -934,7 +934,7 @@ public class d4rkAvatarOptimizer : MonoBehaviour
 
                     for(int i = 0; i < materialSlotCount && !propertyExists; ++i) {
                         // check the default materials
-                        if(renderer.sharedMaterials[i].HasProperty(materialProperty)) {
+                        if(renderer.sharedMaterials[i]?.HasProperty(materialProperty) ?? false) {
                             propertyExists = true;
                             break;
                         }
@@ -942,7 +942,7 @@ public class d4rkAvatarOptimizer : MonoBehaviour
                         // check the material swaps
                         if(swaps.TryGetValue((binding.path, i), out var mats)) {
                             foreach(Material mat in mats) {
-                                if(mat.HasProperty(materialProperty)) {
+                                if(mat?.HasProperty(materialProperty) ?? false) {
                                     propertyExists = true;
                                     break;
                                 }


### PR DESCRIPTION
I find this helps a lot with mesh merge consistency. Especially when building for quest where the material properties that were being animated no longer exist.