### PR TITLE
Fix display name of the script in editor

### DIFF
--- a/Editor/d4rkAvatarOptimizer.cs
+++ b/Editor/d4rkAvatarOptimizer.cs
@@ -28,6 +28,7 @@ using BlendableLayer = VRC.SDKBase.VRC_AnimatorLayerControl.BlendableLayer;
 #endif
 
 [HelpURL("https://github.com/d4rkc0d3r/d4rkAvatarOptimizer/blob/main/README.md")]
+[AddComponentMenu("d4rk Avatar Optimizer")]
 public class d4rkAvatarOptimizer : MonoBehaviour
 #if HAS_IEDITOR_ONLY
 , VRC.SDKBase.IEditorOnly


### PR DESCRIPTION
Makes the script show up as "d4rk Avatar Optimizer" instead of "D 4rk Avatar Optimizer"