### PR TITLE
Keep original uv0.z

### DIFF
--- a/Editor/d4rkAvatarOptimizer.cs
+++ b/Editor/d4rkAvatarOptimizer.cs
@@ -5145,7 +5145,15 @@ public class d4rkAvatarOptimizer : MonoBehaviour, VRC.SDKBase.IEditorOnly
                     targetVertices.Add(sourceVertices[vertIndex]);
                     targetNormals.Add(sourceNormals[vertIndex]);
                     targetTangents.Add(sourceTangents[vertIndex]);
-                    targetUv[0].Add(new Vector4(sourceUv[vertIndex].x, sourceUv[vertIndex].y, sourceUv[vertIndex].z + (blobMeshID << 12), 0));
+					
+                    if (WritePropertiesAsStaticValues)
+                    {
+                        targetUv[0].Add(new Vector4(sourceUv[vertIndex].x, sourceUv[vertIndex].y, blobMeshID << 12, 0));
+                    }
+                    else
+                    {
+                        targetUv[0].Add(sourceUv[vertIndex]);
+                    }
                 }
 
                 for (var matID = 0; matID < skinnedMesh.sharedMaterials.Length; matID++)


### PR DESCRIPTION
It would be nice if uv0.z from the original mesh could be preserved. In this case I am using a shader that stores my own material IDs in uv0.z but d4rkAvatarOptimizer removes it.
I don't expect this to be used together at the same time with the material merging optimizer feature, so it shouldnt break anything.