### PR TITLE
Enable some basic shader locking optimizations for SPS penetrators

### DIFF
--- a/Editor/ShaderAnalyzer.cs
+++ b/Editor/ShaderAnalyzer.cs
@@ -1231,7 +1231,8 @@ namespace d4rkpl4y3r.AvatarOptimizer
                         && lines[lineIndex + 1][0] != '{'
                         && lines[lineIndex + 1][0] != '}'
                         && lines[lineIndex + 1][0] != '#'
-                        && !lines[lineIndex + 1].StartsWithSimple("return"))
+                        && !lines[lineIndex + 1].StartsWithSimple("return")
+                        && !lines[lineIndex].StartsWithSimple("SPS_TEX_DEFINE"))
                     {
                         lineIndex++;
                     }

--- a/Editor/d4rkAvatarOptimizer.cs
+++ b/Editor/d4rkAvatarOptimizer.cs
@@ -200,7 +200,9 @@ public class d4rkAvatarOptimizer : MonoBehaviour, VRC.SDKBase.IEditorOnly
             OptimizeMaterialSwapMaterials();
             Profiler.StartNextSection("OptimizeMaterialsOnNonSkinnedMeshes()");
             OptimizeMaterialsOnNonSkinnedMeshes();
-            Profiler.StartNextSection("SaveOptimizedMaterials()");
+            Profiler.StartNextSection("OptimizeMaterialsOnPartialExclusions()");
+			OptimizeMaterialsOnPartialExclusions();
+			Profiler.StartNextSection("SaveOptimizedMaterials()");
             DisplayProgressBar("Reload optimized materials", 0.60f);
             SaveOptimizedMaterials();
             Profiler.StartNextSection("DestroyUnusedGameObjects()");
@@ -4773,6 +4775,25 @@ public class d4rkAvatarOptimizer : MonoBehaviour, VRC.SDKBase.IEditorOnly
         }
     }
 
+	// super basic material optimization for partially excluded transforms (sps)
+	private void OptimizeMaterialsOnPartialExclusions() 
+    {
+        var partialExclusions = GetPartiallyExcludedTransforms();
+		var skinnedMeshRenderers = GetRootTransform().GetComponentsInChildren<SkinnedMeshRenderer>(true)
+			.Where(smr => partialExclusions.Contains(smr.transform) && smr.sharedMesh != null).ToArray();
+
+        for(int meshRenderIndex = 0; meshRenderIndex < skinnedMeshRenderers.Length; meshRenderIndex++) 
+        {
+			var meshRenderer = skinnedMeshRenderers[meshRenderIndex];
+            var path = GetPathToRoot(meshRenderer);
+
+			var optimizeMaterialWrapper = meshRenderer.sharedMaterials.Select(m => new List<(Material, List<string>)>() { (m, new List<string> { path } ) }).ToList();
+			var optimizedMaterials = CreateOptimizedMaterials(optimizeMaterialWrapper, 0, path);
+
+			meshRenderer.sharedMaterials = optimizedMaterials;
+		}
+	}
+
     private Vector3 CleanUpSmallValues(Vector3 value, float threshold = 1e-6f)
     {
         value.x = value.x < threshold && value.x > -threshold ? 0 : value.x;
@@ -5597,6 +5618,24 @@ public class d4rkAvatarOptimizer : MonoBehaviour, VRC.SDKBase.IEditorOnly
         // flush particle system cache since we merged meshes
         cache_ParticleSystemsUsingRenderer = null;
     }
+
+	// partial set of exclusions to still attempt to do basic shader optimization on
+    // but nothing else
+	private HashSet<Transform> cache_GetPartiallyExcludedTransforms;
+    public HashSet<Transform> GetPartiallyExcludedTransforms() {
+		if(cache_GetPartiallyExcludedTransforms != null)
+			return cache_GetPartiallyExcludedTransforms;
+
+        cache_GetPartiallyExcludedTransforms = new HashSet<Transform>();
+		var partialExcludedTransforms = FindAllPenetrators()
+            .Select(p => p.transform)
+            .Where(t => !ExcludeTransforms.Contains(t) && IsSPSPenetratorRoot(t)).ToList();
+
+		foreach(var excludedTransform in partialExcludedTransforms) {
+			cache_GetPartiallyExcludedTransforms.Add(excludedTransform);
+		}
+        return cache_GetPartiallyExcludedTransforms;
+	}
 
     private HashSet<Transform> cache_GetAllExcludedTransforms;
     public HashSet<Transform> GetAllExcludedTransforms() {


### PR DESCRIPTION
The performance of some of my avatars has been suffering for a while now because my shader heavily relies on
the shader optimizer to lock it but it was being completely skipped for SPS penetrators

This adds just shader optimization for SPS and nothing else, so hopefully no vertex explosions this time, not touching the vertex ids or the mesh.

I had to add a special case to the shader analyzer because one of the macros SPS adds was not compatible with
the optimizer.

It should still fully exclude things that are in the manual exclusions list, but I am not super familiar with this codebase so...