### PR TITLE
Fix mesh material ID breaking certain shaders

### DIFF
--- a/Editor/ShaderAnalyzer.cs
+++ b/Editor/ShaderAnalyzer.cs
@@ -1981,8 +1981,6 @@ namespace d4rkpl4y3r.AvatarOptimizer
         {
             output.Add("struct " + name + "Wrapper");
             output.Add("{");
-            if (addMeshMaterialID)
-                output.Add("uint d4rkAvatarOptimizer_MeshMaterialID : d4rkAvatarOptimizer_MeshMaterialID;");
             foreach (var line in funcParams)
             {
                 if (line.StartsWithSimple("#"))
@@ -2005,6 +2003,8 @@ namespace d4rkpl4y3r.AvatarOptimizer
                     output.Add($"// raw line: {line}");
                 }
             }
+            if (addMeshMaterialID)
+                output.Add("uint d4rkAvatarOptimizer_MeshMaterialID : d4rkAvatarOptimizer_MeshMaterialID;");
             output.Add("};");
         }
         


### PR DESCRIPTION
After optimizing my shader, the wrapped vertex output was being interpreted as unwrapped by the fragment shader. I'm not sure if that's intended. Moving the mesh material ID to the end of the struct prevents it from confusing the fragment shader.

```hlsl
#pragma vertex d4rkAvatarOptimizer_vertexWithWrapper
#pragma fragment Fragment

// ...later

struct vertexOutputWrapper
{
    uint d4rkAvatarOptimizer_MeshMaterialID : d4rkAvatarOptimizer_MeshMaterialID;
    FragmentData returnWrappedStruct;
};
struct vertexInputWrapper
{
    VertexData v;
};
vertexOutputWrapper d4rkAvatarOptimizer_vertexWithWrapper(vertexInputWrapper d4rkAvatarOptimizer_vertexInput)

// ...later

float4 Fragment(FragmentData i, bool facing: SV_IsFrontFace): SV_TARGET
```