### PR TITLE
Fix triangle inflation when optimizing modified meshes

### DIFF
--- a/Editor/d4rkAvatarOptimizer.cs
+++ b/Editor/d4rkAvatarOptimizer.cs
@@ -5165,7 +5165,10 @@ public class d4rkAvatarOptimizer : MonoBehaviour, VRC.SDKBase.IEditorOnly
                 {
                     var indexMap = new Dictionary<int, int>();
                     int internalMaterialID = uniqueMatchedSlots[i].Select((slot, index) => (slot, index)).First(t => t.slot.material == matchedSlots[i][k].material).index;
-                    int materialSubMeshId = Math.Min(mesh.subMeshCount - 1, matchedSlots[i][k].index);
+                    int requestedSubMeshId = matchedSlots[i][k].index;
+                    if (requestedSubMeshId >= mesh.subMeshCount)
+                        continue;
+                    int materialSubMeshId = requestedSubMeshId;
                     var sourceIndices = mesh.GetIndices(materialSubMeshId);
                     for (int j = 0; j < sourceIndices.Length; j++)
                     {
@@ -5894,15 +5897,16 @@ public class d4rkAvatarOptimizer : MonoBehaviour, VRC.SDKBase.IEditorOnly
 
                 for (var matID = 0; matID < skinnedMesh.sharedMaterials.Length; matID++)
                 {
-                    int clampedSubMeshID = Math.Min(matID, mesh.subMeshCount - 1);
-                    int[] indices = mesh.GetIndices(clampedSubMeshID);
+                    if (matID >= mesh.subMeshCount)
+                        continue;
+                    int[] indices = mesh.GetIndices(matID);
                     for (uint i = 0; i < indices.Length; i++)
                     {
                         indices[i] += indexOffset;
                     }
                     materialSlotRemap[(newPath, targetIndices.Count)] = (GetPathToRoot(skinnedMesh), matID);
                     targetIndices.Add(indices);
-                    targetTopology.Add(mesh.GetTopology(clampedSubMeshID));
+                    targetTopology.Add(mesh.GetTopology(matID));
                 }
             }
             Profiler.EndSection();


### PR DESCRIPTION
When meshes have fewer submeshes than material slots, the optimizer was reading the same submesh multiple times and duplicating vertices. Skip out-of-bounds material slots instead of clamping to fix the issue. I'm not sure about the consequences of this, but I'm open to discussion.

This addresses weird situations where you wind up with more triangles ingame than you do in the editor:

<img width="327" height="72" alt="image" src="https://github.com/user-attachments/assets/f5b30bb3-18e9-4a50-b39e-91bd5cae4633" />
<img width="282" height="136" alt="image" src="https://github.com/user-attachments/assets/61dfed8a-e684-4f91-8fac-a009de034aa3" />

And after the patch:

<img width="198" height="77" alt="image" src="https://github.com/user-attachments/assets/89702085-3430-4c2b-9dec-dcbc8d4137a0" />


Close enough, anyway. 