### PR TITLE
Add optional NDMF build hook

### DIFF
--- a/Editor/AvatarBuildHook.cs
+++ b/Editor/AvatarBuildHook.cs
@@ -1,7 +1,6 @@
-﻿#if UNITY_EDITOR
-using System;
-using UnityEngine;
+#if UNITY_EDITOR
 using UnityEditor;
+using UnityEngine;
 using VRC.SDKBase.Editor.BuildPipeline;
 
 namespace d4rkpl4y3r.AvatarOptimizer
@@ -11,71 +10,19 @@ namespace d4rkpl4y3r.AvatarOptimizer
     {
         // Modular Avatar is at -25, we want to be after that. However usually vrcsdk removes IEditorOnly at -1024.
         // MA patches that to happen last so we can only be at -15 if MA is installed otherwise our component will be removed before getting run.
-        #if MODULAR_AVATAR_EXISTS
+#if MODULAR_AVATAR_EXISTS
         public int callbackOrder => -15;
-        #else
+#else
         public int callbackOrder => -1025;
-        #endif
-
-        static private bool didRunInPlayMode = false;
-        [InitializeOnEnterPlayMode]
-        static void OnEnterPlaymodeInEditor(EnterPlayModeOptions options)
-        {
-            didRunInPlayMode = false;
-        }
+#endif
 
         public bool OnPreprocessAvatar(GameObject avatarGameObject)
         {
-            var optimizers = avatarGameObject.GetComponentsInChildren<d4rkAvatarOptimizer>(includeInactive: false);
-            if (optimizers.Length > 1)
-            {
-                Debug.LogError($"d4rkAvatarOptimizer skipping avatar {avatarGameObject.name} because multiple optimizer components found on avatar. Remove duplicates before uploading.");
-                return false;
-            }
-            var optimizer = optimizers.Length == 1 ? optimizers[0] : null;
-            if (optimizer == null && AvatarOptimizerSettings.DoOptimizeWithDefaultSettingsWhenNoComponent)
-            {
-                optimizer = avatarGameObject.AddComponent<d4rkAvatarOptimizer>();
-                AvatarOptimizerSettings.ApplyDefaults(optimizer);
-                optimizer.ApplyAutoSettings();
-                optimizer.ApplyOnUpload = true;
-                Debug.Log($"d4rkAvatarOptimizer added default optimizer component to avatar {avatarGameObject.name} because \"Always Optimize on Upload\" is enabled.");
-            }
-            if (optimizer == null)
-            {
-                Debug.Log($"d4rkAvatarOptimizer skipping avatar {avatarGameObject.name} because no optimizer component found.");
-                return true;
-            }
-            if (!optimizer.ApplyOnUpload)
-            {
-                Debug.Log($"d4rkAvatarOptimizer skipping avatar {avatarGameObject.name} because \"Apply On Upload\" is disabled on the optimizer component.");
-                return true;
-            }
-            try
-            {
-                if (Application.isPlaying)
-                {
-                    if (!AvatarOptimizerSettings.DoOptimizeInPlayMode)
-                    {
-                        Debug.Log($"d4rkAvatarOptimizer skipping avatar {avatarGameObject.name} because \"Optimize in Play Mode\" is disabled.");
-                        return true;
-                    }
-                    else if (didRunInPlayMode)
-                    {
-                        Debug.LogWarning($"d4rkAvatarOptimizer skipping avatar {avatarGameObject.name} because it has already optimized an avatar in this play session.");
-                        return true;
-                    }
-                }
-                didRunInPlayMode = Application.isPlaying;
-                Debug.Log($"d4rkAvatarOptimizer optimizing avatar {avatarGameObject.name}.");
-                optimizer.Optimize();
-                return true;
-            }
-            catch (Exception e)
-            {
-                Debug.LogException(e);
-                return false;
-            }
+#if NDMF_EXISTS
+            return true;
+#else
+            return AvatarOptimizationRunner.Run(avatarGameObject);
+#endif
         }
     }
 }

--- a/Editor/AvatarOptimizationRunner.cs
+++ b/Editor/AvatarOptimizationRunner.cs
@@ -1,0 +1,79 @@
+#if UNITY_EDITOR
+using System;
+using UnityEditor;
+using UnityEngine;
+
+namespace d4rkpl4y3r.AvatarOptimizer
+{
+    internal static class AvatarOptimizationRunner
+    {
+        private static bool didRunInPlayMode = false;
+
+        [InitializeOnEnterPlayMode]
+        private static void OnEnterPlaymodeInEditor(EnterPlayModeOptions options)
+        {
+            didRunInPlayMode = false;
+        }
+
+        public static bool Run(GameObject avatarGameObject)
+        {
+            var optimizers = avatarGameObject.GetComponentsInChildren<d4rkAvatarOptimizer>(includeInactive: false);
+            if (optimizers.Length > 1)
+            {
+                Debug.LogError($"d4rkAvatarOptimizer skipping avatar {avatarGameObject.name} because multiple optimizer components found on avatar. Remove duplicates before uploading.");
+                return false;
+            }
+
+            var optimizer = optimizers.Length == 1 ? optimizers[0] : null;
+            if (optimizer == null && AvatarOptimizerSettings.DoOptimizeWithDefaultSettingsWhenNoComponent)
+            {
+                optimizer = avatarGameObject.AddComponent<d4rkAvatarOptimizer>();
+                AvatarOptimizerSettings.ApplyDefaults(optimizer);
+                optimizer.ApplyAutoSettings();
+                optimizer.ApplyOnUpload = true;
+                Debug.Log($"d4rkAvatarOptimizer added default optimizer component to avatar {avatarGameObject.name} because \"Always Optimize on Upload\" is enabled.");
+            }
+
+            if (optimizer == null)
+            {
+                Debug.Log($"d4rkAvatarOptimizer skipping avatar {avatarGameObject.name} because no optimizer component found.");
+                return true;
+            }
+
+            if (!optimizer.ApplyOnUpload)
+            {
+                Debug.Log($"d4rkAvatarOptimizer skipping avatar {avatarGameObject.name} because \"Apply On Upload\" is disabled on the optimizer component.");
+                return true;
+            }
+
+            try
+            {
+                if (Application.isPlaying)
+                {
+                    if (!AvatarOptimizerSettings.DoOptimizeInPlayMode)
+                    {
+                        Debug.Log($"d4rkAvatarOptimizer skipping avatar {avatarGameObject.name} because \"Optimize in Play Mode\" is disabled.");
+                        return true;
+                    }
+
+                    if (didRunInPlayMode)
+                    {
+                        Debug.LogWarning($"d4rkAvatarOptimizer skipping avatar {avatarGameObject.name} because it has already optimized an avatar in this play session.");
+                        return true;
+                    }
+                }
+
+                didRunInPlayMode = Application.isPlaying;
+                Debug.Log($"d4rkAvatarOptimizer optimizing avatar {avatarGameObject.name}.");
+                optimizer.Optimize();
+                return true;
+            }
+            catch (Exception e)
+            {
+                Debug.LogException(e);
+                return false;
+            }
+        }
+    }
+}
+#endif

--- a/Editor/AvatarOptimizationRunner.cs.meta
+++ b/Editor/AvatarOptimizationRunner.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d1c82ff0b31e4dc49a52df634b6d1b36
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Editor/NDMFBuildHook.cs
+++ b/Editor/NDMFBuildHook.cs
@@ -1,0 +1,35 @@
+#if UNITY_EDITOR && NDMF_EXISTS
+using System;
+using nadena.dev.ndmf;
+using UnityEngine;
+
+[assembly: ExportsPlugin(typeof(d4rkpl4y3r.AvatarOptimizer.NDMFBuildHook))]
+
+namespace d4rkpl4y3r.AvatarOptimizer
+{
+    [RunsOnAllPlatforms]
+    internal sealed class NDMFBuildHook : Plugin<NDMFBuildHook>
+    {
+        public override string DisplayName => "d4rkAvatarOptimizer";
+        public override string QualifiedName => "d4rkpl4y3r.d4rkavataroptimizer";
+
+        protected override void Configure()
+        {
+            InPhase(BuildPhase.Optimizing)
+                .AfterPlugin("com.anatawa12.avatar-optimizer")
+                .Run("Run d4rkAvatarOptimizer", ctx =>
+                {
+                    if (!AvatarOptimizationRunner.Run(ctx.AvatarRootObject))
+                    {
+                        throw new InvalidOperationException("d4rkAvatarOptimizer failed to optimize the avatar.");
+                    }
+                });
+        }
+
+        protected override void OnUnhandledException(System.Exception e)
+        {
+            Debug.LogException(e);
+        }
+    }
+}
+#endif

--- a/Editor/NDMFBuildHook.cs.meta
+++ b/Editor/NDMFBuildHook.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9d956057e9624c579e47d40d08e93457
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Editor/d4rkpl4y3r.d4rkavataroptimizer.Editor.asmdef
+++ b/Editor/d4rkpl4y3r.d4rkavataroptimizer.Editor.asmdef
@@ -6,6 +6,7 @@
         "VRC.SDKBase",
         "VRC.SDKBase.Editor",
         "ORL.ShaderGenerator",
+        "nadena.dev.ndmf",
         "nadena.dev.modular-avatar.core",
         "nadena.dev.modular-avatar.core.editor"
     ],
@@ -26,6 +27,11 @@
             "name": "nadena.dev.modular-avatar",
             "expression": "1.6",
             "define": "MODULAR_AVATAR_EXISTS"
+        },
+        {
+            "name": "nadena.dev.ndmf",
+            "expression": "",
+            "define": "NDMF_EXISTS"
         }
     ],
     "noEngineReferences": false


### PR DESCRIPTION
I tried adding an NDMF build hook for d4rkAvatarOptimizer.

When NDMF is available, d4rkAvatarOptimizer now runs in NDMF's `BuildPhase.Optimizing` phase, after `com.anatawa12.avatar-optimizer`. This lets it integrate better with NDMF-based avatar build pipelines and run after Avatar Optimizer.

The existing VRCSDK preprocess hook is still kept as the fallback path when NDMF is not available.

## Changes

- Extracted the shared avatar optimization flow into `AvatarOptimizationRunner`.
- Added `NDMFBuildHook`, exported as an NDMF plugin.
- Runs d4rkAvatarOptimizer after `com.anatawa12.avatar-optimizer`.
- Skips the VRCSDK preprocess hook when `NDMF_EXISTS` is defined to avoid running the optimizer twice.
- Added the NDMF assembly reference and `NDMF_EXISTS` version define.